### PR TITLE
add 7zip-bin-linux as a devDependecy

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "underscore": "^1.8.3"
     },
     "devDependencies": {
+        "7zip-bin-linux": "^1.3.1",
         "electron": "^1.7.11",
         "electron-builder": "^19.55.2",
         "gulp": "^3.9.1",


### PR DESCRIPTION
lack of this library causes an error during compile on Linux (probably just on arch base Linux distros)